### PR TITLE
Multi-target .NET Standard 1.1 and .NET Standard 2.0

### DIFF
--- a/UnicodeInformation/UnicodeInformation.csproj
+++ b/UnicodeInformation/UnicodeInformation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.Net.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <RootNamespace>System.Unicode</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Following [.NET guidelines for open-source libraries](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting):

> **DO** include a `netstandard2.0` target if you require a `netstandard1.x` target.
> All platforms supporting .NET Standard 2.0 will use the `netstandard2.0` target and benefit from having a smaller package graph while older platforms will still work and fall back to using the `netstandard1.x` target.